### PR TITLE
Add min rust version = 1.58.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "melody"
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.58.0"
 
 [dependencies]
 logos = "0.12.0"


### PR DESCRIPTION
It's a minor thing, but the current version of rustc that comes from the Ubuntu apt repositories is 1.57. I had to uninstall and use rustup to get a version of rustc that can compile the project.