### PR TITLE
[BUG] fix 'of' modifier chaining bug

### DIFF
--- a/crates/melody_compiler/src/lib.rs
+++ b/crates/melody_compiler/src/lib.rs
@@ -30,8 +30,6 @@ pub fn compiler(source: &str) -> Result<String, ParseError> {
 
     let mut in_either = false;
 
-    let mut in_modifier = 0;
-
     let mut line: u16 = 0;
 
     let mut quantifier = None;
@@ -154,18 +152,16 @@ pub fn compiler(source: &str) -> Result<String, ParseError> {
 
             // modifiers
             Token::QuantifierExpression(quantity) => {
-                if in_modifier > 0 {
+                if quantifier.is_some() {
                     return Err(create_parse_error(lexer, line));
                 }
-                in_modifier = 2;
                 quantifier = Some(quantity);
                 None
             }
             Token::OpenRangeExpression(range) | Token::RangeExpression(range) => {
-                if in_modifier > 0 {
+                if quantifier.is_some() {
                     return Err(create_parse_error(lexer, line));
                 }
-                in_modifier = 2;
                 quantifier = Some(range);
                 None
             }
@@ -174,26 +170,23 @@ pub fn compiler(source: &str) -> Result<String, ParseError> {
                 None
             }
             Token::SomeExpression => {
-                if in_modifier > 0 {
+                if quantifier.is_some() {
                     return Err(create_parse_error(lexer, line));
                 }
-                in_modifier = 2;
                 quantifier = Some(String::from("+"));
                 None
             }
             Token::OptionExpression => {
-                if in_modifier > 0 {
+                if quantifier.is_some() {
                     return Err(create_parse_error(lexer, line));
                 }
-                in_modifier = 2;
                 quantifier = Some(String::from("?"));
                 None
             }
             Token::AnyExpression => {
-                if in_modifier > 0 {
+                if quantifier.is_some() {
                     return Err(create_parse_error(lexer, line));
                 }
-                in_modifier = 2;
                 quantifier = Some(String::from("*"));
                 None
             }
@@ -248,10 +241,6 @@ pub fn compiler(source: &str) -> Result<String, ParseError> {
             } else {
                 output.push_str(&formatted_token);
             }
-        }
-
-        if in_modifier > 0 {
-            in_modifier -= 1
         }
     }
 

--- a/crates/melody_compiler/src/lib.rs
+++ b/crates/melody_compiler/src/lib.rs
@@ -30,6 +30,8 @@ pub fn compiler(source: &str) -> Result<String, ParseError> {
 
     let mut in_either = false;
 
+    let mut in_modifier = 0;
+
     let mut line: u16 = 0;
 
     let mut quantifier = None;
@@ -152,10 +154,18 @@ pub fn compiler(source: &str) -> Result<String, ParseError> {
 
             // modifiers
             Token::QuantifierExpression(quantity) => {
+                if in_modifier > 0 {
+                    return Err(create_parse_error(lexer, line));
+                }
+                in_modifier = 2;
                 quantifier = Some(quantity);
                 None
             }
             Token::OpenRangeExpression(range) | Token::RangeExpression(range) => {
+                if in_modifier > 0 {
+                    return Err(create_parse_error(lexer, line));
+                }
+                in_modifier = 2;
                 quantifier = Some(range);
                 None
             }
@@ -164,14 +174,26 @@ pub fn compiler(source: &str) -> Result<String, ParseError> {
                 None
             }
             Token::SomeExpression => {
+                if in_modifier > 0 {
+                    return Err(create_parse_error(lexer, line));
+                }
+                in_modifier = 2;
                 quantifier = Some(String::from("+"));
                 None
             }
             Token::OptionExpression => {
+                if in_modifier > 0 {
+                    return Err(create_parse_error(lexer, line));
+                }
+                in_modifier = 2;
                 quantifier = Some(String::from("?"));
                 None
             }
             Token::AnyExpression => {
+                if in_modifier > 0 {
+                    return Err(create_parse_error(lexer, line));
+                }
+                in_modifier = 2;
                 quantifier = Some(String::from("*"));
                 None
             }
@@ -226,6 +248,10 @@ pub fn compiler(source: &str) -> Result<String, ParseError> {
             } else {
                 output.push_str(&formatted_token);
             }
+        }
+
+        if in_modifier > 0 {
+            in_modifier -= 1
         }
     }
 

--- a/crates/melody_compiler/tests/mod.rs
+++ b/crates/melody_compiler/tests/mod.rs
@@ -256,3 +256,13 @@ fn assertion_test() {
     );
     assert_eq!(output.unwrap(), "/(?=a){5}(?<=a){5}(?!a){5}(?<!a){5}/");
 }
+
+#[test]
+fn chain_test() {
+    let output = compiler(
+      r#"
+      any of option of 6 of "test";
+      "#,
+    );
+    assert!(output.is_err())
+}


### PR DESCRIPTION
## What is fixed
The compiler allows the `of` modifier to be chained, even though it ignores the prepending `of` statements.
## Example of Bug
```
--- input ---
6 of 7 of "test";
--- output ---
/(?:test){7}/
```
## How its fixed
The compiler now keeps track of whether the previous token was a modifier. If it was, then it throws a ParseError.

## After Fix
```
--- input ---
6 of 7 of "test";
--- output ---
Error: Unable to parse "7 of"
```

## Test
I've also added a unit test in `crates/melody_compiler/tests/mod.rs`.