### PR TITLE
update IntelliJ plugin to support new 221.* editors

### DIFF
--- a/extensions/intellij/build.gradle.kts
+++ b/extensions/intellij/build.gradle.kts
@@ -1,10 +1,10 @@
 plugins {
-    kotlin("jvm") version "1.5.10"
-    id("org.jetbrains.intellij") version "1.4.0"
+    kotlin("jvm") version "1.6.20"
+    id("org.jetbrains.intellij") version "1.5.2"
 }
 
 group = "dev.tigr"
-version = "0.2"
+version = "0.2.1"
 
 sourceSets["main"].java.srcDirs("src/main/gen")
 
@@ -18,19 +18,13 @@ dependencies {
 
 // See https://github.com/JetBrains/gradle-intellij-plugin/
 intellij {
-    version.set("2021.2")
+    version.set("2022.1")
 }
 tasks {
     patchPluginXml {
         changeNotes.set("""
             <ul>
-                <li>Added let and lazy keyword support</li>
-                <li>Added &lt;backspace&gt;, &lt;boundary&gt;, and &lt;alphanumeric&gt; support</li>
-                <li>Renamed &lt;alphabet&gt; to &lt;alphabetic&gt;</li>
-                <li>Added multi-line comment support</li>
-                <li>Added character range support</li>
-                <li>Added .melody file extension support</li>
-                <li>Switch to new Melody logo!</li>
+                <li>Updated to support 221.* editors</li>
             </ul>
         """.trimIndent())
         version.set(project.version.toString())

--- a/extensions/intellij/src/main/kotlin/dev/tigr/melody/plugin/MelodySyntaxHighlighting.kt
+++ b/extensions/intellij/src/main/kotlin/dev/tigr/melody/plugin/MelodySyntaxHighlighting.kt
@@ -93,7 +93,7 @@ class MelodyColorSettingsPage: ColorSettingsPage {
     override fun getHighlighter(): SyntaxHighlighter = MelodySyntaxHighlighter()
     override fun getAdditionalHighlightingTagToDescriptorMap(): Map<String, TextAttributesKey>? = null
     override fun getAttributeDescriptors(): Array<AttributesDescriptor> = DESCRIPTORS
-    override fun getColorDescriptors(): Array<ColorDescriptor>? = ColorDescriptor.EMPTY_ARRAY
+    override fun getColorDescriptors(): Array<out ColorDescriptor> = ColorDescriptor.EMPTY_ARRAY
     override fun getDemoText(): String = """// you are reading a melody regex file that matches ipv4 addresses
         |<start>;
         |3 of match {


### PR DESCRIPTION
# Description

The IntelliJ plugin's dependencies had to be update to support the new 221.* versions of IntelliJ. I also updated kotlin and bumped the plugin version to 0.2.1

# Type of change

- [ ] 💔 Breaking
- [ ] 🚀 Feature
- [ ] 🐛 Fix
- [x] 🛠️ Tooling
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
